### PR TITLE
Fix SyntaxError on the inform message

### DIFF
--- a/lib/soap.coffee
+++ b/lib/soap.coffee
@@ -232,7 +232,7 @@ acsInform = (xml) ->
     parameterList : parameterValueList(xml.get('ParameterList')),
     deviceId : traverseXml(xml.get('DeviceId')),
     event : event(xml.get('Event')),
-    retryCount : JSON.parse(xml.get('RetryCount').text())
+    retryCount : parseInt(xml.get('RetryCount').text())
   }
 
 


### PR DESCRIPTION
Fix for SyntaxError when parsing the retry count out of the inform message.

```
2 Sep 10:01:58 - fcf528-VMG4380%2DB10A-S130Y05024801: Inform (2 PERIODIC); retry count 0
2014-09-02T18:02:02.893Z - SyntaxError: Unexpected number
    at Object.parse (native)
    at acsInform (/opt/genieacs/lib/soap.js:295:22)
    at Object.exports.request (/opt/genieacs/lib/soap.js:425:39)
    at /opt/genieacs/lib/cwmp.js:641:26
    at getSession (/opt/genieacs/lib/cwmp.js:572:12)
    at IncomingMessage.<anonymous> (/opt/genieacs/lib/cwmp.js:639:12)
    at IncomingMessage.emit (events.js:92:17)
    at _stream_readable.js:938:16
    at process._tickDomainCallback (node.js:463:13)
```

SOAP block:

```
<SOAP-ENV:Envelope
    xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
    xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xmlns:cwmp="urn:dslforum-org:cwmp-1-0">
    <SOAP-ENV:Header>
      <cwmp:ID SOAP-ENV:mustUnderstand="1">1804289383</cwmp:ID>
    </SOAP-ENV:Header>
    <SOAP-ENV:Body>
      <cwmp:Inform>
        <DeviceId>
          <Manufacturer>ZyXEL</Manufacturer>
          <OUI>fcf528</OUI>
          <ProductClass>VMG4380-B10A</ProductClass>
          <SerialNumber>S130Y05024801</SerialNumber>
        </DeviceId>
        <Event SOAP-ENC:arrayType="cwmp:EventStruct[1]">
          <EventStruct>
            <EventCode>2 PERIODIC</EventCode>
            <CommandKey></CommandKey>
          </EventStruct>
        </Event>
        <MaxEnvelopes>1</MaxEnvelopes>
        <CurrentTime>2014-09-02T09:05:22-09:00</CurrentTime>
        <RetryCount>0</RetryCount>
        <ParameterList SOAP-ENC:arrayType="cwmp:ParameterValueStruct[0008]">
            <ParameterValueStruct>
              <Name>InternetGatewayDevice.DeviceSummary</Name>
              <Value xsi:type="xsd:string">InternetGatewayDevice:1.4[](Baseline:1, EthernetLAN:1, Time:1, IPPing:1, DeviceAssociation:1, EthernetWAN:1, VDSL2WAN:1, ADSLWAN:1, ATMLoopback:1, DSLDiagnostics:1, WiFiLAN:1, X_404A03_TrustDomain:1)</Value>
            </ParameterValueStruct>
            <ParameterValueStruct>
              <Name>InternetGatewayDevice.DeviceInfo.SpecVersion</Name>
              <Value xsi:type="xsd:string">1.0</Value>
            </ParameterValueStruct>
            <ParameterValueStruct>
              <Name>InternetGatewayDevice.DeviceInfo.HardwareVersion</Name>
              <Value xsi:type="xsd:string">tmp_hardware1.0</Value>
            </ParameterValueStruct>
            <ParameterValueStruct>
              <Name>InternetGatewayDevice.DeviceInfo.SoftwareVersion</Name>
              <Value xsi:type="xsd:string">1.00(AAFR.0)</Value>
            </ParameterValueStruct>
            <ParameterValueStruct>
              <Name>InternetGatewayDevice.DeviceInfo.ProvisioningCode</Name>
              <Value xsi:type="xsd:string"></Value>
            </ParameterValueStruct>
            <ParameterValueStruct>
              <Name>InternetGatewayDevice.ManagementServer.ConnectionRequestURL</Name>
              <Value xsi:type="xsd:string">http://216.137.210.139:1/</Value>
            </ParameterValueStruct>
            <ParameterValueStruct>
              <Name>InternetGatewayDevice.ManagementServer.ParameterKey</Name>
              <Value xsi:type="xsd:string"></Value>
            </ParameterValueStruct>
            <ParameterValueStruct>
              <Name>InternetGatewayDevice.WANDevice.1.WANConnectionDevice.1.WANPPPConnection.2.ExternalIPAddress</Name>
              <Value xsi:type="xsd:string">216.137.210.139</Value>
            </ParameterValueStruct>
        </ParameterList>
      </cwmp:Inform>
    </SOAP-ENV:Body>
</SOAP-ENV:Envelope>
```
