### PR TITLE
Don't crash if the query params are invalid json

### DIFF
--- a/lib/nbi.coffee
+++ b/lib/nbi.coffee
@@ -339,7 +339,10 @@ listener = (request, response) ->
 
       func = (aliases) ->
         if urlParts.query.query?
-          q = JSON.parse(urlParts.query.query)
+          try
+            q = JSON.parse(urlParts.query.query)
+          catch e
+            q = {}
         else
           q = {}
         q = query.expand(q, aliases) if collectionName is 'devices'

--- a/lib/nbi.coffee
+++ b/lib/nbi.coffee
@@ -341,8 +341,10 @@ listener = (request, response) ->
         if urlParts.query.query?
           try
             q = JSON.parse(urlParts.query.query)
-          catch e
-            q = {}
+          catch err
+            response.writeHead(400)
+            response.end(err.toString())
+            return
         else
           q = {}
         q = query.expand(q, aliases) if collectionName is 'devices'


### PR DESCRIPTION
Fixes a crash that occurs if the json query string parameters are invalid