### PR TITLE
support passphrase in ssl certificate

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -29,6 +29,7 @@ options = {
   CWMP_PORT : {type : 'int', default : 7547},
   CWMP_INTERFACE : {type : 'string', default : '0.0.0.0'},
   CWMP_SSL : {type : 'bool', default : false},
+  CWMP_PASSPHRASE: {type: 'string', default : '' },
 
   NBI_WORKER_PROCESSES : {type : 'int', default : 2},
   NBI_PORT : {type : 'int', default : 7557},

--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -71,7 +71,8 @@ if useHttps
   httpsCert = path.resolve(config.get('CONFIG_DIR'), "#{service}.crt")
   options = {
     key: fs.readFileSync(httpsKey),
-    cert: fs.readFileSync(httpsCert)
+    cert: fs.readFileSync(httpsCert),
+    passphrase: config.get(service.toUpperCase()+'_PASSPHRASE')
   }
   server = require('https').createServer(options, listener)
 else


### PR DESCRIPTION
This patch supports passphrase in ssl certs. You can provide the password in the config/config.json
via the parameter CWMP_PASSPHRASE