### PR TITLE
Added log message for session timeout.

### DIFF
--- a/lib/cwmp.coffee
+++ b/lib/cwmp.coffee
@@ -442,6 +442,7 @@ listener = (httpRequest, httpResponse) ->
         if cwmpRequest.methodRequest?.type isnt 'Inform'
           httpResponse.writeHead(400)
           httpResponse.end('Session is expired')
+          util.log("Session timeout occured")
           return
 
         deviceId = common.generateDeviceId(cwmpRequest.methodRequest.deviceId)


### PR DESCRIPTION
We got a HTTP 400 (Bad request) when transferring large lists of parameters from the CPE to the ACS. It took us a while to figure out that the session timed out because the log messages only showed retries, but not the reason for them.
So it would help tracing back problems if a session timeout would appear in the logs.