### PR TITLE
Add username and password authentication for files to nbi upload

### DIFF
--- a/lib/nbi.coffee
+++ b/lib/nbi.coffee
@@ -334,6 +334,8 @@ listener = (request, response) ->
           oui : request.headers.oui,
           productClass : request.headers.productclass,
           version : request.headers.version,
+          username : request.headers.username,
+          password : request.headers.password
         }
 
         gs = new mongodb.GridStore(db.mongoDb, filename, 'w', {metadata : metadata})

--- a/lib/tasks.coffee
+++ b/lib/tasks.coffee
@@ -342,6 +342,8 @@ this.download = (task, methodResponse, callback) ->
         fileType : file.metadata.fileType,
         fileSize : file.length,
         url : url.format(l),
+        username : file.metadata.username,
+        password : file.metadata.password,
         successUrl : task.successUrl,
         failureUrl : task.failureUrl
       }


### PR DESCRIPTION
I prepared genieacs for authentication for file downloads. The nbi will store username and password for an uploaded file in the mongodb and the cwmp will send those credentials in the download inform message to the CPE.