### PR TITLE
Support for intermediate certificates in SSL

### DIFF
--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -69,9 +69,23 @@ if useHttps
   fs = require 'fs'
   httpsKey = path.resolve(config.get('CONFIG_DIR'), "#{service}.key")
   httpsCert = path.resolve(config.get('CONFIG_DIR'), "#{service}.crt")
+  httpsCa = path.resolve(config.get('CONFIG_DIR'), "#{service}.crt")
+
+  read = require('fs').readFileSync
+  chainLines = fs.readFileSync(httpsCa, 'utf8').split('\n')
+  cert = []
+  ca = []
+  chainLines.forEach (line) ->
+    cert.push line
+    if line.match(/-END CERTIFICATE-/)
+      ca.push cert.join('\n')
+      cert = []
+    return
+
   options = {
     key: fs.readFileSync(httpsKey),
     cert: fs.readFileSync(httpsCert)
+    ca: ca
   }
   server = require('https').createServer(options, listener)
 else

--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -69,7 +69,7 @@ if useHttps
   fs = require 'fs'
   httpsKey = path.resolve(config.get('CONFIG_DIR'), "#{service}.key")
   httpsCert = path.resolve(config.get('CONFIG_DIR'), "#{service}.crt")
-  httpsCa = path.resolve(config.get('CONFIG_DIR'), "#{service}.crt")
+  httpsCa = path.resolve(config.get('CONFIG_DIR'), "#{service}.cabundle.crt")
 
   read = require('fs').readFileSync
   chainLines = fs.readFileSync(httpsCa, 'utf8').split('\n')


### PR DESCRIPTION
This PR adds support for specifying a certificate chain in a file named cwmp.cabundle.crt
This file contains the CA certificate + intermediates. The certificate itself is still in cwmp.crt
