### PR TITLE
Rename FS_IP to FS_HOSTNAME in sample config

### DIFF
--- a/config/config-sample.json
+++ b/config/config-sample.json
@@ -9,7 +9,6 @@
   "NBI_PORT" : 7557,
   "FS_INTERFACE" : "0.0.0.0",
   "FS_PORT" : 7567,
-  "FS_HOSTNAME" : "192.168.0.1",
-  "LOG_INFORMS" : true,
+  "FS_HOSTNAME" : "acs.example.com",
   "DEBUG" : false
 }

--- a/config/config-sample.json
+++ b/config/config-sample.json
@@ -9,7 +9,7 @@
   "NBI_PORT" : 7557,
   "FS_INTERFACE" : "0.0.0.0",
   "FS_PORT" : 7567,
-  "FS_IP" : "192.168.0.1",
+  "FS_HOSTNAME" : "192.168.0.1",
   "LOG_INFORMS" : true,
   "DEBUG" : false
 }


### PR DESCRIPTION
Although the config option FS_IP is still working, I think it should be updated in the sample configuration. I would continue to use 192.168.0.1 as default, because normally, a local network is the place to start for new users.