### PR TITLE
Add config option to bind UDP port to STUN port, allowing UDP Connection Requests to originate from a port shared with the local STUN server.

### DIFF
--- a/config/config-sample.json
+++ b/config/config-sample.json
@@ -10,5 +10,7 @@
   "FS_INTERFACE" : "0.0.0.0",
   "FS_PORT" : 7567,
   "FS_HOSTNAME" : "acs.example.com",
+  "UDP_PORT_BIND": false,
+  "UDP_PORT": 3478,
   "DEBUG" : false
 }

--- a/config/config-sample.json
+++ b/config/config-sample.json
@@ -10,7 +10,5 @@
   "FS_INTERFACE" : "0.0.0.0",
   "FS_PORT" : 7567,
   "FS_HOSTNAME" : "acs.example.com",
-  "UDP_PORT_BIND": false,
-  "UDP_PORT": 3478,
   "DEBUG" : false
 }

--- a/lib/api-functions.coffee
+++ b/lib/api-functions.coffee
@@ -47,11 +47,11 @@ udpConReq = (address, un, key, callback) ->
   message = Buffer.from("GET #{uri} HTTP/1.1\r\nHost: #{address}\r\n\r\n")
 
   client = dgram.createSocket({type:'udp4', reuseAddr:true})
-  if config.get("UDP_PORT_BIND")
+  if config.get("UDP_CONNECTION_REQUEST_PORT")
     # When a device is NAT'ed, the UDP Connection Request must originate from the same address and port used by the STUN server, in order to traverse the firewall.
     # This does require that the Genieacs NBI and STUN server are allowed to bind to the same address and port.
     # The STUN server needs to open its UDP port with the SO_REUSEADDR option, allowing the NBI to also bind to the same port.
-    client.bind({port: config.get("UDP_PORT")})
+    client.bind({port: config.get("UDP_CONNECTION_REQUEST_PORT")})
 
   count = 3
   client.send(message, 0, message.length, port, host, f = (err) ->

--- a/lib/api-functions.coffee
+++ b/lib/api-functions.coffee
@@ -46,7 +46,12 @@ udpConReq = (address, un, key, callback) ->
 
   message = Buffer.from("GET #{uri} HTTP/1.1\r\nHost: #{address}\r\n\r\n")
 
-  client = dgram.createSocket('udp4')
+  client = dgram.createSocket({type:'udp4', reuseAddr:true})
+  if config.get("UDP_PORT_BIND")
+    # When a device is NAT'ed, the UDP Connection Request must originate from the same address and port used by the STUN server, in order to traverse the firewall.
+    # This does require that the Genieacs NBI and STUN server are allowed to bind to the same address and port.
+    # The STUN server needs to open its UDP port with the SO_REUSEADDR option, allowing the NBI to also bind to the same port.
+    client.bind({port: config.get("UDP_PORT")})
 
   count = 3
   client.send(message, 0, message.length, port, host, f = (err) ->

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -78,6 +78,7 @@ function start(service) {
   });
 
   cluster.on("listening", function(worker, address) {
+    if (address.addressType==='udp4') return null; // Ignore UDP port binds
     logger.info({
       message: "Worker listening",
       pid: worker.process.pid,

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -49,6 +49,9 @@ options = {
   FS_LOG_FILE : {type: 'path', default : ''},
   FS_ACCESS_LOG_FILE : {type : 'path', default : ''},
 
+  UDP_PORT_BIND : {type : 'bool', default : false},
+  UDP_PORT : {type : 'int', default : 3478},
+
   DOWNLOAD_TIMEOUT: {type : 'int', default : 3600},
   EXT_TIMEOUT: {type: 'int', default: 3000},
   MAX_CACHE_TTL : {type : 'int', default : 86400},

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -49,8 +49,7 @@ options = {
   FS_LOG_FILE : {type: 'path', default : ''},
   FS_ACCESS_LOG_FILE : {type : 'path', default : ''},
 
-  UDP_PORT_BIND : {type : 'bool', default : false},
-  UDP_PORT : {type : 'int', default : 3478},
+  UDP_CONNECTION_REQUEST_PORT : {type : 'int', default : 0},
 
   DOWNLOAD_TIMEOUT: {type : 'int', default : 3600},
   EXT_TIMEOUT: {type: 'int', default: 3000},


### PR DESCRIPTION
Some devices report a value of "Enabled" or "Disabled" as a bool type.  This adds support for these devices.