### PR TITLE
Config option to set port for UDP Connection Requests

### DIFF
--- a/lib/api-functions.coffee
+++ b/lib/api-functions.coffee
@@ -46,7 +46,12 @@ udpConReq = (address, un, key, callback) ->
 
   message = Buffer.from("GET #{uri} HTTP/1.1\r\nHost: #{address}\r\n\r\n")
 
-  client = dgram.createSocket('udp4')
+  client = dgram.createSocket({type:'udp4', reuseAddr:true})
+  if config.get("UDP_CONNECTION_REQUEST_PORT")
+    # When a device is NAT'ed, the UDP Connection Request must originate from the same address and port used by the STUN server, in order to traverse the firewall.
+    # This does require that the Genieacs NBI and STUN server are allowed to bind to the same address and port.
+    # The STUN server needs to open its UDP port with the SO_REUSEADDR option, allowing the NBI to also bind to the same port.
+    client.bind({port: config.get("UDP_CONNECTION_REQUEST_PORT")})
 
   count = 3
   client.send(message, 0, message.length, port, host, f = (err) ->

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -78,6 +78,7 @@ function start(service) {
   });
 
   cluster.on("listening", function(worker, address) {
+    if (address.addressType==='udp4') return null; // Ignore UDP port binds
     logger.info({
       message: "Worker listening",
       pid: worker.process.pid,

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -49,6 +49,8 @@ options = {
   FS_LOG_FILE : {type: 'path', default : ''},
   FS_ACCESS_LOG_FILE : {type : 'path', default : ''},
 
+  UDP_CONNECTION_REQUEST_PORT : {type : 'int', default : 0},
+
   DOWNLOAD_TIMEOUT: {type : 'int', default : 3600},
   EXT_TIMEOUT: {type: 'int', default: 3000},
   MAX_CACHE_TTL : {type : 'int', default : 86400},


### PR DESCRIPTION
This change adds an option for setting the socket port for UDP Connection Requests .  As per [TR-111](https://www.broadband-forum.org/technical/download/TR-111.pdf), when running in a NAT'ed environment with a STUN server, both the STUN bindings and UDP Connection Requests must to originate from the same socket port; default 3478.

A few STUN servers support the `SO_REUSEADDR` socket option.  One is the [coturn TURN server ](https://github.com/coturn/coturn).  Running coturn as a STUN server is easy, use the `-S` option; `turnserver -S`.

Another STUN server that should soon support the `SO_REUSEADDR` socket option is [Stuntman](https://github.com/jselbie/stunserver).  There is currently an [open pull request](https://github.com/jselbie/stunserver/pull/20) that adds this option.

While operating STUN and GenieACS with this setting turned on, the STUN server is momentarily blocked by the ACS.  This port blocking has the same affect as dropped packets.  Dropped packets are normal network behavior, so both STUN and the CPE continue to maintain a proper binding. 