### PR TITLE
Feature/backend task watcher

### DIFF
--- a/lib/api-functions.coffee
+++ b/lib/api-functions.coffee
@@ -176,7 +176,13 @@ connectionRequest = (deviceId, callback) ->
   )
 
 
-watchTask = (deviceId, taskId, timeout, callback) ->
+watchTask = (deviceId, taskId, options, callback) ->
+  # Options defaults
+  options = options || {}
+  options.delay = options.delay || 500
+  options.timeout = options.timeout || 3600
+  options.makeConnectionRequest = options.makeConnectionRequest || false
+
   setTimeout(() ->
     db.tasksCollection.findOne({_id : taskId}, {'_id' : 1}, (err, task) ->
       return callback(err) if err
@@ -190,13 +196,19 @@ watchTask = (deviceId, taskId, timeout, callback) ->
         if fault
           return callback(null, 'fault')
 
-        if (timeout -= 500) <= 0
+        if (options.timeout -= options.delay) <= 0
           return callback(null, 'timeout')
 
-        watchTask(deviceId, taskId, timeout, callback)
+        # This is used for the background watchTask() calls.
+        # The CPE may be offline, ignoring the connection requests, or missing the original connection requests due to packet loss, so we are trying again in hopes that the CPE will get the messsage.
+        # Because this connectionRequest() is happening in the background, there is no one listening for feedback, thus the callback function is empty.
+        if (options.makeConnectionRequest)
+          connectionRequest(deviceId, () ->)
+
+        watchTask(deviceId, taskId, options, callback)
       )
     )
-  , 500)
+  , options.delay)
 
 
 sanitizeTask = (task, callback) ->

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -51,6 +51,10 @@ options = {
 
   UDP_CONNECTION_REQUEST_PORT : {type : 'int', default : 0},
 
+  BG_TASK_WATCHER : {type : 'bool', default : false},
+  BG_TASK_WATCHER_DELAY : {type : 'int', default : 30000},
+  BG_TASK_WATCHER_TIMEOUT : {type : 'int', default : 180000},
+
   DOWNLOAD_TIMEOUT: {type : 'int', default : 3600},
   EXT_TIMEOUT: {type: 'int', default: 3000},
   MAX_CACHE_TTL : {type : 'int', default : 86400},

--- a/lib/nbi.coffee
+++ b/lib/nbi.coffee
@@ -288,12 +288,18 @@ listener = (request, response) ->
                     response.writeHead(202, err.message, {'Content-Type' : 'application/json'})
                     response.end(JSON.stringify(task))
                   else
-                    apiFunctions.watchTask(deviceId, task._id, config.get('DEVICE_ONLINE_THRESHOLD', deviceId), (err, status) ->
+                    apiFunctions.watchTask(deviceId, task._id, {timeout: config.get('DEVICE_ONLINE_THRESHOLD', deviceId)}, (err, status) ->
                       return throwError(err, response) if err
 
                       if status is 'timeout'
                         response.writeHead(202, 'Task queued but not processed', {'Content-Type' : 'application/json'})
                         response.end(JSON.stringify(task))
+                        if config.get('BG_TASK_WATCHER')
+                          # The task was not completed, possibly because the CPE is offline, ignored the first request, or missed it because of packet loss.
+                          # Let's get another watchTask() running in the background, with less frequent checks, calling connectionRequest() if the task is not finished.
+                          # There is no one to give feedback to, so the callback function is empty.
+                          apiFunctions.watchTask(deviceId, task._id, {timeout: config.get('BG_TASK_WATCHER_TIMEOUT'), delay: config.get('BG_TASK_WATCHER_DELAY'), makeConnectionRequest: true}, () ->)
+
                       else if status is 'fault'
                         db.tasksCollection.findOne({_id : task._id}, (err, task) ->
                           return throwError(err, response) if err


### PR DESCRIPTION
When tasks are created on the NBI using the `&connection_request` option, the `watchTask()` function is called, which periodically checks to see if the task has been completed by the CPE. If the `timeout` is reached and the task is not completed an `HTTP 202` reply is made, letting the NBI client know the task has been scheduled, but isn't completed.

There are multiple reasons a task isn't completed right away; the CPE is offline, the CPE ignored the connection request, or the connection request never made it to the CPE because of packet loss.

This change adds three new config options `BG_TASK_WATCHER`, `BG_TASK_WATCHER_DELAY`, and `BG_TASK_WATCHER_TIMEOUT`.  The default setting for `BG_TASK_WATCHER` is `false`, which keeps the NBI behaving as it does today.  When `BG_TASK_WATCHER` is `true`, if the first `watchTask()` sequence has timed out, a new `watchTask()` is created, but with a timeout of `BG_TASK_WATCHER_TIMEOUT` and a check interval of `BG_TASK_WATCHER_DELAY`.  The default interval is 30 seconds, with a 3 minute timeout.

This second `watchTask()` sequence makes follow up calls to `connectionRequest()`, transmitting new connection requests to the CPE.  After the `timeout` is reached, `watchTask()` is no longer called for the given task.

I've posted to the community, asking if a background task watcher would be useful.  I've received a positive response from the group.  This is a reasonable feature because it keeps the NBI client simplified, while trying to execute on the original request made by the NBI client.
