### PR TITLE
Add support for a non-standard xsd:signedInt type.

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -43,6 +43,7 @@ function sanitizeParameterValue(parameterValue) {
         break;
       case 'xsd:int':
       case 'xsd:unsignedInt':
+      case 'xsd:signedInt':
         if (typeof parameterValue[0] !== 'number') {
           parameterValue[0] = +parameterValue[0];
         }

--- a/lib/soap.js
+++ b/lib/soap.js
@@ -140,7 +140,7 @@ function parameterValueList(xml) {
         parsed = value;
       }
     }
-    else if (valueType === "xsd:int" || valueType === "xsd:unsignedInt") {
+    else if (valueType === "xsd:int" || valueType === "xsd:unsignedInt" || valueType === "xsd:signedInt") {
       parsed = parseInt(value);
       if (isNaN(parsed)) {
         warnings.push({


### PR DESCRIPTION
We have found a CPE that uses this type of some of its vendor specific data model parameters.

It's not an official XSD type so maybe we don't want it in upstream, but we'd rather deploy the upstream than a fork so here it is.

Let me know your thoughts on including this.
