### PR TITLE
fix(cwmp): release session lock in endSession even if saveDevice fails

### DIFF
--- a/lib/cwmp.ts
+++ b/lib/cwmp.ts
@@ -811,11 +811,18 @@ async function endSession(sessionContext: SessionContext): Promise<void> {
     }
   }
 
-  await Promise.all(promises);
-  await lock.releaseLock(
-    `cwmp_session_${sessionContext.deviceId}`,
-    `cwmp_session_${sessionContext.sessionId}`,
-  );
+  try {
+    await Promise.all(promises);
+  } finally {
+    try {
+      await lock.releaseLock(
+        `cwmp_session_${sessionContext.deviceId}`,
+        `cwmp_session_${sessionContext.sessionId}`,
+      );
+    } catch (err) {
+      // Lock may have already expired or been released
+    }
+  }
   if (sessionContext.new) {
     logger.accessInfo({
       sessionContext: sessionContext,


### PR DESCRIPTION
## Problem

In `endSession()`, `releaseLock()` runs sequentially after `await Promise.all(promises)`. If `saveDevice()` or any other promise rejects, the lock is never released and remains in the `locks` collection until TTL expiry (~60-120s). During that window every Inform from the device is rejected with "CPE already in session", creating a retry loop.

## Fix

Wrap `Promise.all()` in `try/finally` to guarantee lock release. An inner `try/catch` around `releaseLock()` prevents a "Lock expired" error from masking the original exception (since `releaseLock()` throws if `deletedCount !== 1`).

## Codebase precedent

This is the exact pattern already used in `api-functions.ts`:
- `deleteDevice()` (L370-387): `try { await Promise.all([...]) } finally { releaseLock() }`
- `deleteFault()` (L395-402): same pattern

`endSession()` is the only lock-acquiring path in cwmp.ts that lacks this protection.

## Production data (v1.2.16)

~25,000 "CPE already in session" errors/day on a production deployment:

| Product Class | Errors | % of total |
|---------------|--------|------------|
| GR241AG       | 12,244 | 92%        |
| HG8247U       | 249    | 1.9%       |
| EG8147X6      | 93     | 0.7%       |
| EG8247W       | 30     | 0.2%       |
| EG8145V5      | 25     | 0.2%       |
| Others        | 15     | ~0%        |

While GR241AG concentrates 92% of errors, this is not model-specific. GR241AG triggers it more often due to heavier WLAN subtree discovery producing larger device documents and slower `saveDevice()` calls, widening the failure window. The presence of Huawei and Zyxel models in the table confirms the bug affects all vendors.

## Safety

| Concern | Risk |
|---------|------|
| releaseLock error masks original | None — inner try/catch absorbs it |
| Double-release | None — endSession is terminal, one call per session |
| Race with lock extend | None — extend only runs during active request |
| Affects HTTP response | None — response sent before endSession |